### PR TITLE
chore: update GitHub actions used in production builds

### DIFF
--- a/.github/workflows/deploy-prd.yaml
+++ b/.github/workflows/deploy-prd.yaml
@@ -25,7 +25,7 @@ jobs:
       
       # Upload artifact to github pages
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 
@@ -46,5 +46,5 @@ jobs:
     steps:
     - name: Deploy to GitHub Pages
       id: deployment
-      uses: actions/deploy-pages@v2
+      uses: actions/deploy-pages@v4
 


### PR DESCRIPTION
## Description

This PR updates the GitHub actions used for production builds, in an attempt to address a [deprecation error](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) which caused previously attempted production deploy to [fail](https://github.com/newsguildny/gavatar/actions/runs/13589123551/job/37990670437).